### PR TITLE
Minor bug fix: convert toString event log args.

### DIFF
--- a/src/utils_eth.ts
+++ b/src/utils_eth.ts
@@ -47,7 +47,7 @@ export async function getDepositedEventsForBlocks(provider: providers.JsonRpcPro
 }
 
 export function isEventForAurora(nearAuroraAccount: string, eventLog: Event): boolean {
-    const recipientMessage = eventLog.args[1];
+    const recipientMessage = eventLog.args[1].toString();
     const recipientArgs = recipientMessage.split(':');
 
     if (recipientArgs.length < 2) {


### PR DESCRIPTION
This bag was quite rare as I noticed it only once. It happened because of the incorrect parameter provided on the Ethereum side, but still, it was annoying to check. This PR fixes that. 