### PR TITLE
Reduce number of rpc requests

### DIFF
--- a/src/eth_generate_proof.ts
+++ b/src/eth_generate_proof.ts
@@ -8,6 +8,7 @@ import {promises as fs} from "fs"
 import {ConnectorType} from './types';
 import Path = require('path');
 import {TreeBuilder} from "./eth_proof_tree_builder";
+import {Formatter} from "@ethersproject/providers";
 
 interface IProof {
     log_index: number;
@@ -61,9 +62,12 @@ function getFilenamePrefix(connectorType: ConnectorType) {
     return filenamePrefix;
 }
 
+const rpcObjFormatter = new Formatter();
+
 export async function findProofForEvent(treeBuilder: TreeBuilder, ethersProvider: ethers.providers.JsonRpcProvider,
                                         connectorType: ConnectorType, eventLog: ethers.Event) : Promise<Uint8Array> {
-    const receipt: any = await eventLog.getTransactionReceipt();
+
+    const receipt: any = rpcObjFormatter.receipt(await ethersProvider.send('eth_getTransactionReceipt', [eventLog.transactionHash]));
     receipt.cumulativeGasUsed = receipt.cumulativeGasUsed.toNumber();
     console.log(`Generating the proof for TX with hash: ${receipt.transactionHash} at height ${receipt.blockNumber}`);
     const blockData = await ethersProvider.send(

--- a/src/static-json-rpc-batch-provider.ts
+++ b/src/static-json-rpc-batch-provider.ts
@@ -1,0 +1,25 @@
+import {Network} from "@ethersproject/networks";
+import {defineReadOnly} from "@ethersproject/properties";
+import {providers} from "ethers";
+
+export class StaticJsonRpcBatchProvider extends providers.JsonRpcBatchProvider {
+    async detectNetwork(): Promise<Network> {
+        let network = this.network;
+        if (network == null) {
+            network = await super.detectNetwork();
+
+            if (!network) {
+                throw Error("no network detected");
+            }
+
+            // If still not set, set it
+            if (this._network == null) {
+                // A static network does not support "any"
+                defineReadOnly(this, "_network", network);
+
+                this.emit("network", network, null);
+            }
+        }
+        return network;
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export enum RetrieveReceiptsMode {
 }
 
 export interface IReceipt {
+    transactionHash: string,
+    blockNumber: number,
     transactionIndex: number,
     logs: Log[],
     logsBloom: string,


### PR DESCRIPTION
This pull request fixes the regression after replacing `web3.BatchRequest`  with `JsonRpcBatchProvider` https://github.com/aurora-is-near/eth-to-near-event-relayer/commit/6dc02cb8604556bf55585ba1fcc562c16a30ce52.
- Implemented Static version of `JsonRpcBatchProvider` which has the same logic as https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#StaticJsonRpcProvider).
- Use raw rpc call instead of `provider.getTransactionReceipt()` to avoid extra rpc call of `getBlockNumber`