### PR TITLE
Fix block number conversion on proof generation

### DIFF
--- a/src/eth_generate_proof.ts
+++ b/src/eth_generate_proof.ts
@@ -74,7 +74,7 @@ export async function findProofForEvent(treeBuilder: TreeBuilder, ethersProvider
     console.log(`Generating the proof for TX with hash: ${receipt.transactionHash} at height ${receipt.blockNumber}`);
     const blockData = await ethersProvider.send(
         'eth_getBlockByNumber',
-        [ethers.BigNumber.from(receipt.blockNumber)._hex, false]);
+        [ethers.utils.hexValue(receipt.blockNumber), false]);
     const tree = await treeBuilder.getTreeForBlock(blockData);
     const proof = await extractProof(blockData, tree, receipt.transactionIndex);
     const logIndexInArray = receipt.logs.findIndex(


### PR DESCRIPTION
The `eth_getBlockByNumber()` expects to receive a block number as a hex string without leading zeroes. Meantime, Ethers's `BigNumber._hex` or `BigNumber.toHexString()` always returns a bytes representation, which is an evenly padded string (with leading zeroes if there are any) which will cause "invalid argument 0: hex number with leading zero digits" error on sending the request. `ethers.utils.hexValue()` method makes a conversion with no unnecessary leading zeros ([docs](https://docs.ethers.org/v5/api/utils/bytes/#utils-hexValue)).