### PR TITLE
Update Mainnet relayer config

### DIFF
--- a/src/json/mainnet-relayer-config.json
+++ b/src/json/mainnet-relayer-config.json
@@ -3,7 +3,7 @@
   "nearNetwork": "mainnet",
 
   "relayerNearAccount": "event-relayer.near",
-  "ethOnNearClientAccount": "client.bridge.near",
+  "ethOnNearClientAccount": "client-eth2.bridge.near",
 
   "erc20LockerAddress": "0x23ddd3e3692d1861ed57ede224608875809e127f",
   "erc271LockerAddress": "",
@@ -23,6 +23,6 @@
   "relayERC20Events": true,
   "relayERC271Events": false,
   "relayOnlyAuroraEvents": false,
-  "relayENearEvents": false,
+  "relayENearEvents": true,
   "retrieveReceiptsMode": "batch"
 }


### PR DESCRIPTION
* Use [client-eth2.bridge.near](https://explorer.near.org/accounts/client-eth2.bridge.near) contract for `EthOnNearClient`.
* Relay `eNEAR` events by default.